### PR TITLE
🎨 Palette: Add focus-visible for button accessibility

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,8 @@
+# 🎨 Palette's Journal - CRITICAL LEARNINGS ONLY
+
+This journal is for documenting critical, codebase-specific UX and accessibility learnings. It is not a log of routine work.
+
+Format:
+`## YYYY-MM-DD - [Title]
+**Learning:** [UX/a11y insight]
+**Action:** [How to apply next time]`

--- a/website/templates/index.html
+++ b/website/templates/index.html
@@ -93,9 +93,12 @@
             a.button:active {
                 transform: translateY(1px) scale(0.997);
             }
-            a.button:hover {
+            a.button:hover,
+            a.button:focus-visible {
                 opacity: 0.9;
                 transform: translateY(-2px);
+                outline: 2px solid var(--fg);
+                outline-offset: 2px;
             }
 
             /* Subtle caption */


### PR DESCRIPTION
### 💡 What
Added a `:focus-visible` state to the primary action buttons on the homepage (`index.html`).

### 🎯 Why
The buttons previously lacked a visible focus indicator, making keyboard navigation difficult and inaccessible for users who rely on it. This change ensures that tabbing to a button provides clear visual feedback, consistent with the styles already present in `base.html`.

### 🖼️ Before/After
**Before:** No visible focus state when tabbing.
**After:** A clear outline appears around the button on focus, as seen in the verification screenshot.
![Verification Screenshot](/home/jules/verification/verification.png)

### ♻️ Accessibility
This change directly improves keyboard navigation accessibility, a fundamental requirement for inclusive web design. It ensures that users can confidently navigate the primary calls-to-action without relying on a mouse.

---
*PR created automatically by Jules for task [13630452787705860852](https://jules.google.com/task/13630452787705860852) started by @HenryTheAddict*