### PR TITLE
🛡️ Sentinel: [Enhancement] Enforce POST for Repack Endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,1 +1,7 @@
 # Sentinel's Journal - Critical Learnings Only
+
+
+## 2024-05-20 - Enforce POST-Only Access for State-Changing Endpoints
+**Vulnerability:** A development-only endpoint (`/api/wallpapers/repack`) that triggers a significant server-side action (repacking all wallpapers) was accessible via a `GET` request.
+**Learning:** Allowing a state-changing operation to be triggered by a `GET` request introduces a Cross-Site Request Forgery (CSRF) vulnerability. An attacker could trick a logged-in developer into visiting a malicious page that contains an image tag (`<img src=".../api/wallpapers/repack">`), causing their browser to trigger the action unintentionally.
+**Prevention:** All endpoints that cause a change in the server's state (e.g., creating, updating, deleting resources) MUST be protected by restricting them to `POST`, `PUT`, `PATCH`, or `DELETE` methods. This ensures that the action cannot be triggered by simple, cross-site URL access.

--- a/website/app.py
+++ b/website/app.py
@@ -71,7 +71,7 @@ def wallpapers():
     return render_template("wallpapers.html")
 
 
-@app.route("/api/wallpapers/repack")
+@app.route("/api/wallpapers/repack", methods=["POST"])
 def repack_wallpapers():
     """Trigger repacking of wallpapers to static folder"""
     if not app.config["DEBUG"]:


### PR DESCRIPTION
**Severity**: MEDIUM
**Vulnerability**: The `/api/wallpapers/repack` endpoint, which performs a state-changing action, was accessible via a `GET` request. This exposed the application to potential Cross-Site Request Forgery (CSRF) attacks.
**Impact**: An attacker could trick a developer into unintentionally triggering the resource-intensive repacking process by embedding the URL in a malicious webpage.
**Fix**: The endpoint has been updated to only accept `POST` requests, which is the standard practice for actions that modify server state, mitigating the CSRF risk.
**Verification**: Confirmed that making a `GET` request to the endpoint now results in a `405 Method Not Allowed` error, while a `POST` request functions as expected.

---
*PR created automatically by Jules for task [1305803475661956536](https://jules.google.com/task/1305803475661956536) started by @HenryTheAddict*