### PR TITLE
🛡️ Sentinel: MEDIUM Fix CSRF on repack endpoint

### DIFF
--- a/website/app.py
+++ b/website/app.py
@@ -71,7 +71,7 @@ def wallpapers():
     return render_template("wallpapers.html")
 
 
-@app.route("/api/wallpapers/repack")
+@app.route("/api/wallpapers/repack", methods=["POST"])
 def repack_wallpapers():
     """Trigger repacking of wallpapers to static folder"""
     if not app.config["DEBUG"]:


### PR DESCRIPTION
🚨 **Severity**: MEDIUM
💡 **Vulnerability**: The development-only endpoint `/api/wallpapers/repack` was accessible via a GET request. State-changing actions should not be performed on GET requests as they can be triggered maliciously through Cross-Site Request Forgery (CSRF).
🎯 **Impact**: A malicious website could embed the URL to this endpoint, causing a developer's browser to trigger a resource-intensive repacking process on the server, potentially leading to a Denial of Service (DoS).
🔧 **Fix**: The endpoint has been modified to only accept POST requests. This is a standard security practice for actions that change server state.
✅ **Verification**: The route decorator in `website/app.py` has been updated from `@app.route("/api/wallpapers/repack")` to `@app.route("/api/wallpapers/repack", methods=["POST"])`. Any attempt to access this endpoint with a GET request will now fail.

---
*PR created automatically by Jules for task [7779540622202732849](https://jules.google.com/task/7779540622202732849) started by @HenryTheAddict*