### PR TITLE
🎨 Palette: Add aria-label to shuffle button

### DIFF
--- a/website/templates/wallpapers.html
+++ b/website/templates/wallpapers.html
@@ -694,7 +694,7 @@
                         ${
                             pack.shuffle_enabled
                                 ? `
-                        <button class="btn btn-outline-danger" onclick="testShuffle('${pack.id}')" title="Test shuffle">
+                        <button class="btn btn-outline-danger" onclick="testShuffle('${pack.id}')" title="Test shuffle" aria-label="Test shuffle">
                             <i class="fas fa-dice"></i>
                         </button>
                         `


### PR DESCRIPTION
This change improves accessibility by adding an `aria-label` to the icon-only "Test shuffle" button on the wallpapers page, making it understandable to screen reader users.

---
*PR created automatically by Jules for task [8921058606073035697](https://jules.google.com/task/8921058606073035697) started by @HenryTheAddict*