### PR TITLE
🎨 Palette: Improve accessibility and navigation on wallpapers page

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-05-14 - Accessible Toggle Pattern and Standard Navigation
+**Learning:** Interactive components like toggle switches should use semantic `<button type="button" role="switch">` elements with `aria-checked` to ensure keyboard accessibility and screen reader support. Additionally, brand headers should always be interactive links to the homepage to meet universal navigation expectations.
+**Action:** Replace `div`-based custom controls with semantic buttons and ensure all logo/title elements are wrapped in `<a>` tags.

--- a/website/templates/wallpapers.html
+++ b/website/templates/wallpapers.html
@@ -130,6 +130,12 @@
                 box-shadow: 0 0 15px rgba(220, 38, 38, 0.5);
             }
 
+            .toggle-switch:focus-visible {
+                outline: 2px solid #ffffff;
+                outline-offset: 4px;
+                box-shadow: 0 0 0 4px rgba(220, 38, 38, 0.4);
+            }
+
             .toggle-slider {
                 position: absolute;
                 top: 2px;
@@ -229,7 +235,11 @@
         <nav class="glass-effect border-0 shadow-lg mb-8">
             <div class="container mx-auto px-4 py-4">
                 <div class="flex items-center justify-between">
-                    <div class="flex items-center space-x-3">
+                    <a
+                        href="/"
+                        class="flex items-center space-x-3 no-underline"
+                        aria-label="HueSurf Home"
+                    >
                         <div
                             class="w-10 h-10 bg-gradient-red rounded-xl flex items-center justify-center shadow-lg"
                         >
@@ -245,7 +255,7 @@
                                 Professional wallpaper management
                             </p>
                         </div>
-                    </div>
+                    </a>
                     <div class="flex items-center space-x-4">
                         <span class="text-gray-400 text-sm">v1.0.0</span>
                         <div
@@ -301,12 +311,15 @@
                                         >Shuffle on New Tab</span
                                     >
                                 </div>
-                                <div
+                                <button
+                                    type="button"
                                     class="toggle-switch"
                                     id="global-shuffle-toggle"
+                                    role="switch"
+                                    aria-label="Toggle shuffle on new tab"
                                 >
                                     <div class="toggle-slider"></div>
-                                </div>
+                                </button>
                             </div>
                             <p class="text-gray-400 text-sm">
                                 Automatically change wallpapers when opening new
@@ -330,9 +343,15 @@
                                         >Remember Wallpaper</span
                                     >
                                 </div>
-                                <div class="toggle-switch" id="remember-toggle">
+                                <button
+                                    type="button"
+                                    class="toggle-switch"
+                                    id="remember-toggle"
+                                    role="switch"
+                                    aria-label="Toggle remember wallpaper"
+                                >
                                     <div class="toggle-slider"></div>
-                                </div>
+                                </button>
                             </div>
                             <p class="text-gray-400 text-sm">
                                 Keep your last selected wallpaper across
@@ -517,6 +536,7 @@
                             document.getElementById("global-shuffle");
                         checkbox.checked = !checkbox.checked;
                         this.classList.toggle("active", checkbox.checked);
+                        this.setAttribute("aria-checked", checkbox.checked);
                         localStorage.setItem("globalShuffle", checkbox.checked);
                         showNotification(
                             `Shuffle ${checkbox.checked ? "enabled" : "disabled"}`,
@@ -531,6 +551,7 @@
                             document.getElementById("remember-wallpaper");
                         checkbox.checked = !checkbox.checked;
                         this.classList.toggle("active", checkbox.checked);
+                        this.setAttribute("aria-checked", checkbox.checked);
                         localStorage.setItem(
                             "rememberWallpaper",
                             checkbox.checked,
@@ -554,12 +575,17 @@
                 document.getElementById("remember-wallpaper").checked =
                     rememberWallpaper;
 
-                document
-                    .getElementById("global-shuffle-toggle")
-                    .classList.toggle("active", globalShuffle);
-                document
-                    .getElementById("remember-toggle")
-                    .classList.toggle("active", rememberWallpaper);
+                const shuffleToggle = document.getElementById(
+                    "global-shuffle-toggle",
+                );
+                const rememberToggle =
+                    document.getElementById("remember-toggle");
+
+                shuffleToggle.classList.toggle("active", globalShuffle);
+                shuffleToggle.setAttribute("aria-checked", globalShuffle);
+
+                rememberToggle.classList.toggle("active", rememberWallpaper);
+                rememberToggle.setAttribute("aria-checked", rememberWallpaper);
             }
 
             // Load wallpaper packs
@@ -694,7 +720,7 @@
                         ${
                             pack.shuffle_enabled
                                 ? `
-                        <button class="btn btn-outline-danger" onclick="testShuffle('${pack.id}')" title="Test shuffle">
+                        <button class="btn btn-outline-danger" onclick="testShuffle('${pack.id}')" title="Test shuffle" aria-label="Test shuffle">
                             <i class="fas fa-dice"></i>
                         </button>
                         `
@@ -995,6 +1021,7 @@
                 searchToggle.className = "btn btn-outline-light btn-sm";
                 searchToggle.innerHTML = '<i class="fas fa-search"></i>';
                 searchToggle.title = "Toggle Search";
+                searchToggle.setAttribute("aria-label", "Toggle search");
 
                 searchToggle.addEventListener("click", function () {
                     const isVisible = searchInput.style.display !== "none";


### PR DESCRIPTION
### 💡 What:
Improved accessibility and navigation on the `wallpapers.html` page.

### 🎯 Why:
- The previous toggle switches were inaccessible to keyboard and screen reader users.
- Icon-only buttons lacked descriptive labels.
- The brand title was not a link, violating common web navigation patterns.

### 📸 Before/After:
- Toggles now support keyboard focus and state announcements.
- Brand logo/title is now a clickable link to home.

### ♿ Accessibility:
- Added `role="switch"` and `aria-checked` to toggles.
- Added `aria-label` to all icon-only buttons.
- Implemented `:focus-visible` for clear focus indicators.

---
*PR created automatically by Jules for task [9691451554655549258](https://jules.google.com/task/9691451554655549258) started by @HenryTheAddict*