### PR TITLE
🎨 Palette: Improved wallpaper interface accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-01-24 - Accessible Toggles and Icon Buttons
+**Learning:** Custom UI elements like toggle switches created with `div` tags are inaccessible to keyboard users and screen readers. Converting them to `<button type="button" role="switch">` with `aria-checked` and adding `:focus-visible` styles with sufficient contrast (e.g., `2px solid #dc2626`) significantly improves accessibility.
+**Action:** Always use semantic button elements for interactive toggles and ensure all icon-only buttons have descriptive `aria-label` attributes.

--- a/website/templates/wallpapers.html
+++ b/website/templates/wallpapers.html
@@ -130,6 +130,11 @@
                 box-shadow: 0 0 15px rgba(220, 38, 38, 0.5);
             }
 
+            .toggle-switch:focus-visible {
+                outline: 2px solid #dc2626;
+                outline-offset: 4px;
+            }
+
             .toggle-slider {
                 position: absolute;
                 top: 2px;
@@ -251,6 +256,8 @@
                         <div
                             class="w-2 h-2 bg-red-500 rounded-full animate-pulse shadow-lg"
                             title="System Online"
+                            role="img"
+                            aria-label="System Online"
                         ></div>
                     </div>
                 </div>
@@ -301,12 +308,16 @@
                                         >Shuffle on New Tab</span
                                     >
                                 </div>
-                                <div
+                                <button
+                                    type="button"
+                                    role="switch"
+                                    aria-checked="true"
+                                    aria-label="Toggle Shuffle on New Tab"
                                     class="toggle-switch"
                                     id="global-shuffle-toggle"
                                 >
-                                    <div class="toggle-slider"></div>
-                                </div>
+                                    <span class="toggle-slider"></span>
+                                </button>
                             </div>
                             <p class="text-gray-400 text-sm">
                                 Automatically change wallpapers when opening new
@@ -330,9 +341,16 @@
                                         >Remember Wallpaper</span
                                     >
                                 </div>
-                                <div class="toggle-switch" id="remember-toggle">
-                                    <div class="toggle-slider"></div>
-                                </div>
+                                <button
+                                    type="button"
+                                    role="switch"
+                                    aria-checked="false"
+                                    aria-label="Toggle Remember Wallpaper"
+                                    class="toggle-switch"
+                                    id="remember-toggle"
+                                >
+                                    <span class="toggle-slider"></span>
+                                </button>
                             </div>
                             <p class="text-gray-400 text-sm">
                                 Keep your last selected wallpaper across
@@ -517,6 +535,7 @@
                             document.getElementById("global-shuffle");
                         checkbox.checked = !checkbox.checked;
                         this.classList.toggle("active", checkbox.checked);
+                        this.setAttribute("aria-checked", checkbox.checked.toString());
                         localStorage.setItem("globalShuffle", checkbox.checked);
                         showNotification(
                             `Shuffle ${checkbox.checked ? "enabled" : "disabled"}`,
@@ -531,6 +550,7 @@
                             document.getElementById("remember-wallpaper");
                         checkbox.checked = !checkbox.checked;
                         this.classList.toggle("active", checkbox.checked);
+                        this.setAttribute("aria-checked", checkbox.checked.toString());
                         localStorage.setItem(
                             "rememberWallpaper",
                             checkbox.checked,
@@ -554,12 +574,14 @@
                 document.getElementById("remember-wallpaper").checked =
                     rememberWallpaper;
 
-                document
-                    .getElementById("global-shuffle-toggle")
-                    .classList.toggle("active", globalShuffle);
-                document
-                    .getElementById("remember-toggle")
-                    .classList.toggle("active", rememberWallpaper);
+                const shuffleToggle = document.getElementById("global-shuffle-toggle");
+                const rememberToggle = document.getElementById("remember-toggle");
+
+                shuffleToggle.classList.toggle("active", globalShuffle);
+                shuffleToggle.setAttribute("aria-checked", globalShuffle.toString());
+
+                rememberToggle.classList.toggle("active", rememberWallpaper);
+                rememberToggle.setAttribute("aria-checked", rememberWallpaper.toString());
             }
 
             // Load wallpaper packs
@@ -694,7 +716,7 @@
                         ${
                             pack.shuffle_enabled
                                 ? `
-                        <button class="btn btn-outline-danger" onclick="testShuffle('${pack.id}')" title="Test shuffle">
+                        <button class="btn btn-outline-danger" onclick="testShuffle('${pack.id}')" title="Test shuffle" aria-label="Test shuffle for ${pack.name}">
                             <i class="fas fa-dice"></i>
                         </button>
                         `
@@ -995,6 +1017,7 @@
                 searchToggle.className = "btn btn-outline-light btn-sm";
                 searchToggle.innerHTML = '<i class="fas fa-search"></i>';
                 searchToggle.title = "Toggle Search";
+                searchToggle.setAttribute("aria-label", "Toggle search bar");
 
                 searchToggle.addEventListener("click", function () {
                     const isVisible = searchInput.style.display !== "none";


### PR DESCRIPTION
### 💡 What:
Improved the accessibility and user experience of the wallpaper management page (`/wallpapers`).

### 🎯 Why:
The previous interface used non-semantic `div` elements for toggles, making them inaccessible to keyboard users and screen readers. Icon-only buttons also lacked descriptive labels.

### 📸 Before/After:
- **Before:** Toggles were unreachable via `Tab` key; screen readers only saw "Shuffle on New Tab" text without an associated control.
- **After:** Toggles are focusable with a clear red outline; screen readers identify them as "switch" with "on/off" states.

### ♿ Accessibility:
- Implemented `role="switch"` with `aria-checked`.
- Added `:focus-visible` with `2px solid #dc2626` and `4px` offset.
- Added `aria-label` to all icon-only interactive elements.
- Added `role="img"` to the status pulse indicator.

---
*PR created automatically by Jules for task [16271106464669388276](https://jules.google.com/task/16271106464669388276) started by @HenryTheAddict*